### PR TITLE
Rename dissertation thesis to doctoral thesis

### DIFF
--- a/ctuth-names.tex
+++ b/ctuth-names.tex
@@ -119,7 +119,7 @@
 		doctype-slovak = { Diplomová ~ práca }
 	},
 	xdoctype-D .meta:n = {
-		doctype-english = { Dissertation ~ Thesis },
+		doctype-english = { Doctoral ~ Thesis },
 		doctype-czech = { Disertační ~ práce },
 		doctype-slovak = { Dizertačná ~ práca }
 	},


### PR DESCRIPTION
``Dissertation Thesis`` does not make sense (thesis=dissertation). Either ``Dissertation`` or  ``Doctoral Thesis`` is correct. I propose to use ``Doctoral Thesis``.